### PR TITLE
Add the description about Active Record and DB Adapter's gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ Just install the gem:
 $ gem install schemadoc
 ```
 
+In addition, install `Active Record` and your database adapter's gem such as `mysql2`
+
+```
+$ gem install activerecord
+$ gem install mysql2
+```
+
 
 ## License
 


### PR DESCRIPTION
Hi. `schemadoc` is very useful, thanks :)

Though I tried to install and exec `schemadoc` along `Install` section in README.md, I failed to exec as below.

```bash
$ schemadoc 
Traceback (most recent call last):
	7: from /home/takiya/.rbenv/versions/2.5.0/bin/schemadoc:23:in `<main>'
...
	1: from /home/takiya/.rbenv/versions/2.5.0/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
/home/takiya/.rbenv/versions/2.5.0/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require': cannot load such file -- active_record (LoadError)
```

So I installed `Active Record` and exec `schemadoc` again. But failed.

```bash
$ schemadoc
schemadoc/1.1.0 on Ruby 2.5.0 (2017-12-25) [x86_64-linux]
{"database"=>
  {"adapter"=>"mysql2",
   "host"=>"123.123.123.123",
   "port"=>12345,
   "username"=>"username",
   "password"=>"password",
   "database"=>"db_name"}}
...
Traceback (most recent call last):
	10: from /home/takiya/.rbenv/versions/2.5.0/bin/schemadoc:23:in `<main>'
...
	 1: from /home/takiya/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/activerecord-5.1.5/lib/active_record/connection_adapters/connection_specification.rb:185:in `spec'
/home/takiya/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/activerecord-5.1.5/lib/active_record/connection_adapters/connection_specification.rb:188:in `rescue in spec': Specified 'mysql2' for database adapter, but the gem is not loaded. Add `gem 'mysql2'` to your Gemfile (and ensure its version is at the minimum required by ActiveRecord). (Gem::LoadError)
```

Yeah, I need to install `mysql2` gem, too.

I add abobe description to `README.md`. This is very very minor update, sorry :)
